### PR TITLE
Update xDebug script with PHP 7.4 new paths

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -11,5 +11,5 @@ RUN wget http://xdebug.org/files/xdebug-2.9.1.tgz \
     && phpize \
     && ./configure \
     && make \
-    && sudo cp modules/xdebug.so /usr/lib/php/20170718 \
-    && sudo bash -c "echo -e '\nzend_extension = /usr/lib/php/20170718/xdebug.so\n[XDebug]\nxdebug.remote_enable = 1\nxdebug.remote_autostart = 1\n' >> /etc/php/7.2/cli/php.ini"
+    && sudo cp modules/xdebug.so /usr/lib/php/20190902 \
+    && sudo bash -c "echo -e '\nzend_extension = /usr/lib/php/20190902/xdebug.so\n[XDebug]\nxdebug.remote_enable = 1\nxdebug.remote_autostart = 1\n' >> /etc/php/7.4/cli/php.ini"


### PR DESCRIPTION
The current installed PHP version is 7.4. The update has changed some config directories and the PR aims to fix the build process.